### PR TITLE
return false on undefined other node

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,5 +17,5 @@ module.exports = contains;
  */
 
 function contains (node, other) {
-  return node === other || !!(node.compareDocumentPosition(other) & 16);
+  return other && (node === other || !!(node.compareDocumentPosition(other) & 16) );
 }


### PR DESCRIPTION
`document.body.contains(null)` returns `false`. The polyfill throws an error with `document.compareDocumentPosition(null)`

See WICG/inert#62